### PR TITLE
Add function to parse key-value pairs for PLP taglines

### DIFF
--- a/indexShop.js
+++ b/indexShop.js
@@ -21,6 +21,9 @@
 		var shoppage_featured,
 			shoppage_related,
 			packpage_carousel;
+
+		var shoppage_category_taglines = _.where(records, {"Channel": "NAV BAR-Category Taglines"});
+		shoppage_category_taglines = util.getPLPTaglines(shoppage_category_taglines);
 	
 		var shoppage_featured = _.where(records, {"Channel": "NAV BAR-Featured Packs Carousel"});
 		//var shoppage_related = _.where(records, {"Channel": "NAV BAR-Related Recipes Carousel"});
@@ -39,6 +42,7 @@
 
 		var output = {
 				shoppage: {
+					category_taglines: shoppage_category_taglines,
 					featured: shoppage_featured,
 					//related: shoppage_related
 				},

--- a/util.js
+++ b/util.js
@@ -164,6 +164,14 @@
 		return obj;
 	}
 
+	function _getPLPTaglines(record) {
+		var obj = {};
+		_.each(record, function(row) {
+			obj[row.Location] = row.value;
+		});
+		return obj;
+	}
+
 	function _getRelated(record){
 		return _.extend({}, _getItems(record), _getButton(record));
 	}
@@ -212,6 +220,7 @@
 	exports.getQuote = _getQuote;
 	exports.group = _group;
 	exports.getItems = _getItems;
+	exports.getPLPTaglines = _getPLPTaglines;
 	exports.getTriptychItems = _getTriptychItems;
 	exports.getButton = _getButton;
 	exports.getHeroItems = _getHeroItems;


### PR DESCRIPTION
Necessary for MSW-1104. Adds a new function for parsing `shoppage` section will simply grab the key-value pairs as shown in the screenshot below. The outcome should be an object that looks like this:

```
	"shoppage": {
		"category_taglines": {
			"marthasfavorites": "This is marthas favorites",
			"white": "These are the whites"
		},
		"featured": {
			"tagline": "Where you'll find this wine",
			"headline": "Featured in These Packs"
		}
	}
```

![plp_category_taglines_example](https://user-images.githubusercontent.com/4806609/28346257-a12e2c8e-6be4-11e7-9b4a-94d5c34e5259.png)
